### PR TITLE
Bugfix + improved error handling

### DIFF
--- a/lib/dl.js
+++ b/lib/dl.js
@@ -17,16 +17,18 @@ function download(url, filepath, onError, onDone, onProgress) {
     var isAbort = false;
     req.on('response', function(res) {
             out.on('finish', () => {
-                //校验是否现在完整
+                // Check if the download was aborted on purpose
                 if (isAbort) {
                     return;
                 };
                 let fileSize = fs.statSync(filepath)['size'];
-                let isFullDown = totalSize === curSize;
-                //如果没有下载完整则为下载失败
+                
+                let isFullDown = totalSize === curSize || totalSize === -1;
+                // Check if the file was fully downloaded
                 if (!isFullDown) {
                     onError({
-                        msg: '文件校验失败'
+                        msg: 'The download was incomplete.',
+                        errcode: 'err_dlincomplete'
                     })
                 } else {
                     onProgress(totalSize, totalSize);
@@ -38,10 +40,16 @@ function download(url, filepath, onError, onDone, onProgress) {
                 }
             });
             let totalSize = parseInt(res.headers['content-length'], 10); //文件大小的长度
+            // Set the totalSize to -1 if the server doesn't report it
+            if(isNaN(totalSize)) {
+                totalSize = -1;
+            }
+        
             let curSize = 0; //文件接收大小
 
             res.on('data', function(chunk) {
                 curSize += chunk.length;
+                
                 //判读是否显示进度条
                 if (onProgress) {
                     onProgress(curSize, totalSize)


### PR DESCRIPTION
Changed functionality:
- totalSize is set to -1 if the server doesn't report it
- if totalSize isn't provided, no error will be shown if the file download ended
- Added err_code to the error message shown when the downloaded file was incomplete and translated the message